### PR TITLE
style: refactoring, cleanup, #LuaTeX

### DIFF
--- a/demo.typ
+++ b/demo.typ
@@ -1,11 +1,9 @@
 #set page(width: 35em, height: auto)
-#set text(font: "New Computer Modern")
 
-#import "@preview/metalogo:1.1.0": TeX, LaTeX, XeLaTeX, XeTeX, LuaLaTeX
+#import "metalogo.typ": *
 
-#LaTeX is a typestting program based on #TeX. Some people use #XeLaTeX
-(sometimes #XeTeX), or #LuaLaTeX to typeset their documents.
+#LaTeX is a typesetting program based on #TeX. Some people use #XeLaTeX
+(sometimes #XeTeX), or #LuaLaTeX (sometimes #LuaTeX) to typeset their documents.
 
-People who are afraid of #LaTeX and its complex macro system may use typst
+People who are afraid of #LaTeX and its complex macro system may use Typst
 instead.
-

--- a/metalogo.typ
+++ b/metalogo.typ
@@ -1,11 +1,56 @@
 // TODO: base should *actually* be lowered by 0.5ex, but Typst does not yet
 // have an ex unit, only em. See https://github.com/typst/typst/issues/2405
-#let baseline-drop = 0.22em
+#let (TeX, LaTeX, XeTeX, XeLaTeX, LuaTeX, LuaLaTeX) = {
+  // Vertical change for specific letters
+  // TODO: change to ex units when supported
+  let drop = (
+    e: 0.22em, // Baseline drop for 'E' in TeX and XeTeX
+    a: -0.2em, // Baseline drop for 'A' in LaTeX
+  )
 
-#let TeX = [#box[T#h(-.1667em)#box[#move(dy: baseline-drop)[E]]#h(-.125em)X]]
-#let Xe = [#box[X#h(-.1667em)#box[#move(dy: baseline-drop)[#scale(x: -100%)[E]]]#h(-.125em)]]
-#let LaTeX = [#box[L#h(-.33em)#box[#move(dy: -0.2em)[#text(0.7em)[A]]]#h(-.15em)#TeX]]
-#let XeTeX = [#box[#Xe#TeX]]
-#let XeLaTeX = [#box[#Xe#LaTeX]]
-#let LuaLaTeX = [#box[Lua#LaTeX]]
+// Kerning for specific letter-pairs
+  let kern = (
+    t-e: -0.1667em, // Kerning between 'T' and 'E' in TeX
+    e-x: -0.125em,  // Kerning between 'E' and 'X' in TeX
 
+    l-a: -0.33em,   // Kerning between 'L' and 'A' in LaTeX
+    a-t: -0.15em,   // Kerning between 'A' and 'T' in LaTeX
+
+    x-e: -0.1667em, // Kerning between 'X' and 'E' in XeTeX
+    e-t: -0.125em,  // Kerning between 'E' and 'T' in XeTeX
+  )
+
+  // Sizes for specific letters
+  let size = (
+    a: 0.7em, // Size of 'A' in LaTeX
+  )
+
+  // Helper functions
+  let lower(y, body) = box(baseline: y)[#body]  // Note the negative sign
+  let rev(body)      = scale(x: -100%)[#body]
+  let ncm(body)      = text(font: "New Computer Modern")[#body]
+
+  // Build components
+  let TeX      = [T#h(kern.t-e)#lower(drop.e)[E]#h(kern.e-x)X]
+  let A        = lower(drop.a)[#text(size: size.a)[A]]
+  let LaTeX    = [L#h(kern.l-a)#A#h(kern.a-t)#TeX]
+  let Xe       = [X#h(kern.x-e)#lower(drop.e)[#rev[E]]#h(kern.e-t)]
+  let XeTeX    = [#Xe#TeX]
+  let XeLaTeX  = [#Xe#LaTeX]
+  let LuaTeX   = [Lua#TeX]
+  let LuaLaTeX = [Lua#LaTeX]
+
+  // Return tuple of exported function
+  //
+  // Forces each to New Computer Modern and shifts down by `drop.e` since the E
+  // in TeX is meant to be below the baseline. Note that `lower` wraps content
+  // with `box` so it's unbreakable.
+  (
+    ncm(lower(drop.e, TeX)),
+    ncm(lower(drop.e, LaTeX)),
+    ncm(lower(drop.e, XeTeX)),
+    ncm(lower(drop.e, XeLaTeX)),
+    ncm(lower(drop.e, LuaTeX)),
+    ncm(lower(drop.e, LuaLaTeX)),
+  )
+}


### PR DESCRIPTION
- forced output font to always use New Computer Modern
- factored out magic numbers into constants (drop, kern, size dictionaries)
- factored out helpers for `box(baseline: ..)` and `scale(x: -100%)`
- factored out A component
- changed to function which only returns exported symbols, where all temporaries are just local variables/functions
- added LuaTeX
- fixed demo.typ:
  - imports local file and `*`, more useful for testing
  - fixed typos ("typesetting", "Typst")
  - mentioned LuaTeX